### PR TITLE
Fix refs prefix bug

### DIFF
--- a/examples/asyncapi/README.md
+++ b/examples/asyncapi/README.md
@@ -53,14 +53,14 @@ npx yaml-to-json-schema examples/asyncapi/sample.yaml
       "properties": {
         "id": {
           "description": "User Id",
-          "$ref": "#definitions/id"
+          "$ref": "#/definitions/id"
         },
         "full_name": {
           "description": "User full name",
           "type": "string"
         },
         "username": {
-          "$ref": "#definitions/username"
+          "$ref": "#/definitions/username"
         }
       }
     },
@@ -75,7 +75,7 @@ npx yaml-to-json-schema examples/asyncapi/sample.yaml
           "type": "string"
         },
         "username": {
-          "$ref": "#definitions/username"
+          "$ref": "#/definitions/username"
         }
       }
     },
@@ -98,35 +98,35 @@ npx yaml-to-json-schema examples/asyncapi/sample.yaml
           ]
         },
         "datetime": {
-          "$ref": "#definitions/datetime"
+          "$ref": "#/definitions/datetime"
         }
       }
     }
   },
   "properties": {
     "id": {
-      "$ref": "#definitions/id"
+      "$ref": "#/definitions/id"
     },
     "username": {
-      "$ref": "#definitions/username"
+      "$ref": "#/definitions/username"
     },
     "datetime": {
-      "$ref": "#definitions/datetime"
+      "$ref": "#/definitions/datetime"
     },
     "MQTTQoSHeader": {
-      "$ref": "#definitions/MQTTQoSHeader"
+      "$ref": "#/definitions/MQTTQoSHeader"
     },
     "MQTTRetainHeader": {
-      "$ref": "#definitions/MQTTRetainHeader"
+      "$ref": "#/definitions/MQTTRetainHeader"
     },
     "user": {
-      "$ref": "#definitions/user"
+      "$ref": "#/definitions/user"
     },
     "userCreate": {
-      "$ref": "#definitions/userCreate"
+      "$ref": "#/definitions/userCreate"
     },
     "signup": {
-      "$ref": "#definitions/signup"
+      "$ref": "#/definitions/signup"
     }
   }
 }
@@ -204,7 +204,7 @@ import Schemas from 'generated.json'
 const ajv = new Ajv({ allErrors: true })
 
 for(const schemaName in Schemas.definitions) {
-  ajv.addSchema(Schemas.definitions[schemaName], '#definitions/' + schemaName)
+  ajv.addSchema(Schemas.definitions[schemaName], '#/definitions/' + schemaName)
 }
 
 export const UserValidator = ajv.compile(Schemas.definitions.user)

--- a/examples/openapi/README.md
+++ b/examples/openapi/README.md
@@ -14,7 +14,7 @@ npx yaml-to-json-schema examples/openapi/petstore-expanded.yaml
     "Pet": {
       "allOf": [
         {
-          "$ref": "#definitions/NewPet"
+          "$ref": "#/definitions/NewPet"
         },
         {
           "type": "object",
@@ -63,13 +63,13 @@ npx yaml-to-json-schema examples/openapi/petstore-expanded.yaml
   },
   "properties": {
     "Pet": {
-      "$ref": "#definitions/Pet"
+      "$ref": "#/definitions/Pet"
     },
     "NewPet": {
-      "$ref": "#definitions/NewPet"
+      "$ref": "#/definitions/NewPet"
     },
     "Error": {
-      "$ref": "#definitions/Error"
+      "$ref": "#/definitions/Error"
     }
   }
 }
@@ -118,7 +118,7 @@ import Schemas from 'generated.json'
 const ajv = new Ajv({ allErrors: true })
 
 for(const schemaName in Schemas.definitions) {
-  ajv.addSchema(Schemas.definitions[schemaName], '#definitions/' + schemaName)
+  ajv.addSchema(Schemas.definitions[schemaName], '#/definitions/' + schemaName)
 }
 
 export const NewPetValidator = ajv.compile(Schemas.definitions.NewPet)

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ const fixAddons = (doc: Prop, src: Src): void => {
 const fixProperty = (prop: Prop, src: Src): Prop => {
 
   if (prop.$ref) {
-    prop.$ref = '#definitions/' + getKey(prop.$ref, src)
+    prop.$ref = '#/definitions/' + getKey(prop.$ref, src)
   } else if (prop.type === 'object') {
     fixRef(prop, src)
   } else if (prop.type === 'array') {
@@ -131,7 +131,7 @@ const prepare = async (doc: Doc, src: Src): Promise<JsonSchema> => {
   for(const key in schemas) {
     definitions[key] = await loadSchema(schemas[key], src)
     // @ts-ignore // @TODO fix this issue. Error TS2740: Type '{ $ref: string; }'
-    properties[key] = { $ref: '#definitions/' + key }
+    properties[key] = { $ref: '#/definitions/' + key }
   }
 
   return {


### PR DESCRIPTION
I encountered an issue while converting OpenAPI v3 to JSON schemas in combination with AJV validator. When attempting to validate objects against the schema using the AJV validator, I noticed a problem. Both AJV and Visual Studio Code (VSCODE) were unable to resolve $ref paths when they were prefixed as `#definitions/`. However, I discovered that the issue was resolved when the paths were prefixed with `#/definitions/`.

Closes #3 